### PR TITLE
Implement basic synth architecture with timer-based DAC output

### DIFF
--- a/include/Constants.h
+++ b/include/Constants.h
@@ -3,8 +3,7 @@
 
 #define TIMER_GROUP 0
 #define TIMER_DIVIDER 80
-#define TIMER_INTERVAL 50 // microseconds
-
-#define DAC_CHANNEL_1 DAC_CHANNEL_1
+#define TIMER_INTERVAL 50
+#define DAC_CHANNEL_1 DAC1_CHANNEL_1
 
 #endif

--- a/src/core/GenerativeSequencer.h
+++ b/src/core/GenerativeSequencer.h
@@ -1,18 +1,13 @@
-// src/core/GenerativeSequencer.h
-class GenerativeSequencer {
-private:
-    static constexpr size_t MAX_STEPS = 16;
-    SequenceStep steps[MAX_STEPS];
-    std::array<float, AUDIO_BUFFER_SIZE> audioBuffer;
-    uint8_t sequenceLength;
-    uint8_t currentStep;
-    float phase;
-    float sampleRate;
+#ifndef GENERATIVE_SEQUENCER_H
+#define GENERATIVE_SEQUENCER_H
 
+class GenerativeSequencer {
 public:
-    GenerativeSequencer(Adafruit_SSD1306& display);
-    GenerativeSequencer(const GenerativeSequencer&) = delete;
-    GenerativeSequencer& operator=(const GenerativeSequencer&) = delete;
-    GenerativeSequencer(GenerativeSequencer&&) noexcept = default;
-    GenerativeSequencer& operator=(GenerativeSequencer&&) noexcept = default;
-    ~GenerativeSequencer() = default;
+    GenerativeSequencer();
+    float generateSample();
+    void update();
+private:
+    // Implementation details
+};
+
+#endif


### PR DESCRIPTION
This PR implements the basic synthesizer architecture with timer-based DAC output. Changes include:

- Created `BasicSynth.ino` example with timer and DAC initialization
- Added core constants in `Constants.h` for timer and DAC configuration
- Simplified `GenerativeSequencer` class interface with basic audio generation methods

Key features:
- Timer-based interrupt for consistent sample generation
- DAC output for audio signal generation
- Basic sequencer infrastructure for audio synthesis
- Thread-safe sample generation using critical sections

Technical details:
- Timer configured at 50μs intervals
- 8-bit DAC output (0-255 range)
- Sample normalization to [-1.0, 1.0] range